### PR TITLE
Update README to reflect RN 0.49 breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In `AppDelegate.m`, replace the old host loading code with this:
 
 ```objective-c
   NSString *host = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"RNHost"];
-  jsCodeLocation = [NSURL URLWithString: [NSString stringWithFormat:@"http://%@:8081/index.ios.bundle?platform=ios&dev=true", host]];
+  jsCodeLocation = [NSURL URLWithString: [NSString stringWithFormat:@"http://%@:8081/index.bundle?platform=ios&dev=true", host]];
 ```
 
 Run the initializer that automatically adds a Run Script phase, in your React Native project folder:


### PR DESCRIPTION
In [React Native 0.49](https://github.com/facebook/react-native/releases/tag/v0.49.0) `index.ios.js` and `index.android.js` were removed and replaced with a single `index.js`. This also caused the RN packager to stop serving `index.ios.bundle`; `index.bundle` must be requested instead.

Thank you for creating this useful project! -chrmcg