### PR TITLE
Add support for ngrok tunnels

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ In `AppDelegate.m`, replace the old host loading code with this:
 
 ```objective-c
   NSString *host = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"RNHost"];
-  jsCodeLocation = [NSURL URLWithString: [NSString stringWithFormat:@"http://%@:8081/index.bundle?platform=ios&dev=true", host]];
+  NSString *port = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"RNPort"];
+  jsCodeLocation = [NSURL URLWithString: [NSString stringWithFormat:@"http://%@:%@/index.bundle?platform=ios&dev=true", host, port]];
 ```
 
 Run the initializer that automatically adds a Run Script phase, in your React Native project folder:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In `AppDelegate.m`, replace the old host loading code with this:
 
 ```objective-c
   NSString *host = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"RNHost"];
-  jsCodeLocation = [NSURL URLWithString: [NSString stringWithFormat:@"http://%@:8081/index.ios.bundle?platform=ios&dev=true", host]];
+  jsCodeLocation = [NSURL URLWithString: [NSString stringWithFormat:@"http://%@:8081/index.bundle?platform=ios&dev=true", host]];
 ```
 
 Run the initializer that automatically adds a Run Script phase, in your React Native project folder:

--- a/boot.sh
+++ b/boot.sh
@@ -1,8 +1,20 @@
 #!/bin/sh
-# todo: improve this, some boxes has en5, en1, etc
 
-# use ifconfig, remove loopack and virtualbox IPs
-rnhost=`ifconfig | sed -En 's/127.0.0.1//;s/127.94.0.(1|2)//;s/192.168.99.*//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p' | head -n1`
+# see if ngrok is active and pointing to :8081
+ngrok_is_on=`curl -s http://127.0.0.1:4040/api/tunnels | jq '.tunnels | .[] | select(.proto == "http") | .config.addr == "localhost:8081"'`
+
+if [ "$ngrok_is_on" == "true" ]
+then
+    # get ngrok address, set port to 80 (ngrok.io will not accept requests at :8081)
+    rnhost=`curl -s http://127.0.0.1:4040/api/tunnels | jq -r '.tunnels | .[] | select(.proto == "http") | .public_url' | sed -e 's/^http:\/\///g'`
+    rnport=80
+else
+    # todo: improve this, some boxes has en5, en1, etc
+    # use ifconfig, remove loopback and virtualbox IPs, set port to 8081
+    rnhost=`ifconfig | sed -En 's/127.0.0.1//;s/192.168.99.*//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p' | head -n1`
+    rnport=8081
+fi
+
 plist=${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/../${INFOPLIST_PATH}
 
 case "$CONFIGURATION" in
@@ -26,3 +38,9 @@ echo Setting React Native RNHost variable to $rnhost
 /usr/libexec/PlistBuddy -c "Add :RNHost string" $plist
 /usr/libexec/PlistBuddy -c "Set :RNHost ${rnhost}" $plist
 echo Done.
+
+echo Setting React Native RNPort variable to $rnport
+/usr/libexec/PlistBuddy -c "Add :RNPort string" $plist
+/usr/libexec/PlistBuddy -c "Set :RNPort ${rnport}" $plist
+echo Done.
+

--- a/boot.sh
+++ b/boot.sh
@@ -1,7 +1,12 @@
 #!/bin/sh
 
-# see if ngrok is active and pointing to :8081
-ngrok_is_on=`curl -s http://127.0.0.1:4040/api/tunnels | jq '.tunnels | .[] | select(.proto == "http") | .config.addr == "localhost:8081"'`
+if [ -z `which jq` ]
+then
+    ngrok_is_on=false
+else
+    # see if ngrok is active and pointing to :8081
+    ngrok_is_on=`curl -s http://127.0.0.1:4040/api/tunnels | jq '.tunnels | .[] | select(.proto == "http") | .config.addr == "localhost:8081"'`
+fi
 
 if [ "$ngrok_is_on" == "true" ]
 then


### PR DESCRIPTION
I often have to develop on a network which blocks incoming requests, so my phone can't get the RN bundle from the packager on my machine even when I specify the correct IP address.

I normally use [ngrok](https://ngrok.com/) to get around this by creating a reverse proxy that forwards traffic from `<assigned subdomain>.ngrok.io` to `localhost:8081`.

This PR edits `boot.sh` to check whether an ngrok tunnel is running on `:8081`, and if so, points the bundle to the public ngrok address instead of the computer's IP address. It also sets the port to 80 since ngrok will not accept incoming traffic on ports other than 80.

If no ngrok tunnel is running, it sets the port back to 8081 and sets the host to the computer's IP as usual.

This PR depends on [`jq`](https://stedolan.github.io/jq/) but the script won't break if `jq` is not installed; the ngrok feature will just be skipped.

I know this is a somewhat large change and I understand if you don't want to merge it. I just wanted to make people aware of this option for developing RN apps on-device when you happen to be stuck using a network that blocks incoming requests.